### PR TITLE
Normalize $count value

### DIFF
--- a/includes/shortcode-strong.php
+++ b/includes/shortcode-strong.php
@@ -182,6 +182,7 @@ function wpmtst_strong_shortcode( $atts, $content = null, $parent_tag ) {
 	 * @since 1.16.1
 	 */
 	if ( $count > 0 ) {
+		$count = min( $count, count( $query->posts ) );
 		$query->posts = array_slice( $query->posts, 0, $count );
 		$query->post_count = $count;
 	}


### PR DESCRIPTION
To not get fantom posts.
Because if you are using
```
[strong count="5"]...[/strong]
```
and in reality you have only `2` posts - you get extra `5-2` posts :)