### PR TITLE
Fixing the submit form-field css class

### DIFF
--- a/includes/functions-template-form.php
+++ b/includes/functions-template-form.php
@@ -417,7 +417,7 @@ add_action( 'wpmtst_form_after_fields', 'wpmtst_form_captcha' );
  */
 function wpmtst_form_submit_button( $preview = false ) {
 	?>
-	<div class="form-field submit">
+	<div class="form-field wpmtst-submit">
 		<label><input type="<?php echo $preview ? 'button' : 'submit'; ?>" id="wpmtst_submit_testimonial" name="wpmtst_submit_testimonial" value="<?php esc_attr_e( wpmtst_get_form_message( 'form-submit-button' ) ); ?>" class="button" tabindex="0"></label>
 	</div>
 	<?php

--- a/templates-scss/_partials/_structure-form.scss
+++ b/templates-scss/_partials/_structure-form.scss
@@ -4,7 +4,7 @@
   .form-field {
     margin-bottom: 1.5em;
 
-    &.submit {
+    &.wpmtst-submit {
       margin-bottom: 0;
     }
   }


### PR DESCRIPTION
I am using the Uno theme from Woo Themes.
Currently this is how I see the Form to submit a new testimonial:

![image](https://user-images.githubusercontent.com/498934/32985216-b9eb0e2a-ccc6-11e7-927f-accdff75399e.png)

This is due to usage of a quite common class name `submit`.

In this fix instead of using of a `submit` class name for a form field I have replaced it with a more strict (namespaced) class name `wpmtst-submit`.