### PR TITLE
Preserve assigned post while rendering shortcode template

### DIFF
--- a/includes/class-strong-view-display.php
+++ b/includes/class-strong-view-display.php
@@ -158,10 +158,15 @@ class Strong_View_Display extends Strong_View {
 
 		} else {
 
+			global $post;
+			$post_before = $post;
+
 			ob_start();
 			/** @noinspection PhpIncludeInspection */
 			include( $this->template_file );
 			$html = ob_get_clean();
+
+			$post = $post_before;
 
 		}
 


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/issues/7461

This pull request seeks to resolve an issue where Strong Testimonials causes the `$post` global to be indirectly reassigned in its rendering of the shortcode template.

More information: 

- https://github.com/WordPress/gutenberg/issues/7461#issuecomment-400429477
- https://core.trac.wordpress.org/ticket/18408

Effectively, this is simply ensuring that Strong Testimonials cleans up after itself by ensuring that the `$post` variable is set back to its original value once the template has been rendered. 